### PR TITLE
fix microsteps and rotation distance for stock configuration

### DIFF
--- a/klipper_config/printer.cfg
+++ b/klipper_config/printer.cfg
@@ -112,8 +112,8 @@ kick_start_time: 0.5
 step_pin: PE3
 dir_pin: !PE2
 enable_pin: !PE4
-microsteps: 16
-rotation_distance: 20
+microsteps: 32
+rotation_distance: 40
 endstop_pin: !PA15
 position_endstop: 1
 position_max: 255
@@ -123,8 +123,8 @@ homing_speed: 40
 step_pin: PE0
 dir_pin: !PB9
 enable_pin: !PE1
-microsteps: 16
-rotation_distance: 20
+microsteps: 32
+rotation_distance: 40
 endstop_pin: !PD2
 position_endstop: 1
 position_max: 220
@@ -147,8 +147,8 @@ position_max: 200
 step_pin: PD6
 dir_pin: PD3
 enable_pin: !PB3
-microsteps: 32
-rotation_distance: 15.632
+microsteps: 16
+rotation_distance: 7.315
 max_extrude_only_distance: 1400.0
 nozzle_diameter: 0.400
 filament_diameter: 1.750


### PR DESCRIPTION
X/Y pulleys 20T for 2GT belts provides rotation distance 40mm
X/Y 2225 drivers configured for 32 microsteps on MKS Nano4 by default
E0 driver  configured for 16 microsteps on MKS Nano4 by default